### PR TITLE
Jetcam library doesn't work every time, so using OpenCV to open camera

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -1,0 +1,3 @@
+Sarthak Garg
+
+Mayur Nehete

--- a/tasks/human_pose/live_demo.ipynb
+++ b/tasks/human_pose/live_demo.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -33,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -54,9 +54,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<All keys matched successfully>"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "import torch\n",
     "\n",
@@ -76,7 +87,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -95,7 +106,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -113,7 +124,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -131,9 +142,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<All keys matched successfully>"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from torch2trt import TRTModule\n",
     "\n",
@@ -150,9 +172,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "813.84641654119\n"
+     ]
+    }
+   ],
    "source": [
     "import time\n",
     "\n",
@@ -175,7 +205,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -206,7 +236,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -227,43 +257,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from jetcam.usb_camera import USBCamera\n",
-    "# from jetcam.csi_camera import CSICamera\n",
-    "from jetcam.utils import bgr8_to_jpeg\n",
-    "\n",
-    "camera = USBCamera(width=WIDTH, height=HEIGHT, capture_fps=30)\n",
-    "# camera = CSICamera(width=WIDTH, height=HEIGHT, capture_fps=30)\n",
-    "\n",
-    "camera.running = True"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Next, we'll create a widget which will be used to display the camera feed with visualizations."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import ipywidgets\n",
-    "from IPython.display import display\n",
-    "\n",
-    "image_w = ipywidgets.Image(format='jpeg')\n",
-    "\n",
-    "display(image_w)"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -278,25 +271,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
-    "def execute(change):\n",
-    "    image = change['new']\n",
+    "def execute(image):\n",
     "    data = preprocess(image)\n",
     "    cmap, paf = model_trt(data)\n",
     "    cmap, paf = cmap.detach().cpu(), paf.detach().cpu()\n",
     "    counts, objects, peaks = parse_objects(cmap, paf)#, cmap_threshold=0.15, link_threshold=0.15)\n",
-    "    draw_objects(image, counts, objects, peaks)\n",
-    "    image_w.value = bgr8_to_jpeg(image[:, ::-1, :])"
+    "    draw_objects(image, counts, objects, peaks)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If we call the cell below it will execute the function once on the current camera frame."
+    "### We run the camera using OpenCV.\n"
    ]
   },
   {
@@ -305,39 +296,33 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "execute({'new': camera.value})"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Call the cell below to attach the execution function to the camera's internal value.  This will cause the execute function to be called whenever a new camera frame is received."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "camera.observe(execute, names='value')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Call the cell below to unattach the camera frame callbacks."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "camera.unobserve_all()"
+    "import cv2\n",
+    "\n",
+    "cam = cv2.VideoCapture(0)\n",
+    "\n",
+    "cv2.namedWindow(\"test\") #This will open a python window named \"test\"\n",
+    "cam.set(cv2.CAP_PROP_FRAME_WIDTH, WIDTH)\n",
+    "cam.set(cv2.CAP_PROP_FRAME_HEIGHT, HEIGHT)\n",
+    "\n",
+    "img_counter = 0\n",
+    "\n",
+    "while True:\n",
+    "    ret, frame = cam.read()\n",
+    "    frame = cv2.resize(frame,(224,224))\n",
+    "    execute(frame)\n",
+    "    frame = cv2.resize(frame,(640,640))\n",
+    "    cv2.imshow(\"test\", frame)\n",
+    "    if not ret:\n",
+    "        break\n",
+    "    key = cv2.waitKey(1) \n",
+    "    \n",
+    "    #To close the window Press 'Q'\n",
+    "    if key & 0xFF == ord('q') or key ==27:\n",
+    "        break\n",
+    "\n",
+    "cam.release()\n",
+    "\n",
+    "cv2.destroyAllWindows()"
    ]
   }
  ],

--- a/tasks/human_pose/live_demo.py
+++ b/tasks/human_pose/live_demo.py
@@ -1,0 +1,97 @@
+import json
+import trt_pose.coco
+
+import torch
+import torch2trt
+from torch2trt import TRTModule
+
+
+import cv2
+import torchvision.transforms as transforms
+import PIL.Image
+
+from trt_pose.draw_objects import DrawObjects
+from trt_pose.parse_objects import ParseObjects
+
+WIDTH = 224
+HEIGHT = 224
+OPTIMIZED_MODEL = 'resnet18_baseline_att_224x224_A_epoch_249_trt.pth'
+
+
+
+with open('human_pose.json', 'r') as f:
+    human_pose = json.load(f)
+
+topology = trt_pose.coco.coco_category_to_topology(human_pose)
+
+
+num_parts = len(human_pose['keypoints'])
+num_links = len(human_pose['skeleton'])
+
+print("Reading TensorRT model.......")
+model_trt = TRTModule()
+model_trt.load_state_dict(torch.load(OPTIMIZED_MODEL))
+
+print("TensorRT model loaded")
+
+mean = torch.Tensor([0.485, 0.456, 0.406]).cuda()
+std = torch.Tensor([0.229, 0.224, 0.225]).cuda()
+device = torch.device('cuda')
+
+def preprocess(image):
+    global device
+    device = torch.device('cuda')
+    image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+    image = PIL.Image.fromarray(image)
+    image = transforms.functional.to_tensor(image).to(device)
+    image.sub_(mean[:, None, None]).div_(std[:, None, None])
+    return image[None, ...]
+    
+    
+    
+parse_objects = ParseObjects(topology)
+draw_objects = DrawObjects(topology)
+
+
+def execute(change):
+    data = preprocess(change)
+    cmap, paf = model_trt(data)
+    cmap, paf = cmap.detach().cpu(), paf.detach().cpu()
+    counts, objects, peaks = parse_objects(cmap, paf)
+    draw_objects(change, counts, objects, peaks)
+    
+    
+    
+def main():
+
+    cam = cv2.VideoCapture(0)
+
+    cv2.namedWindow("test")
+    cam.set(cv2.CAP_PROP_FRAME_WIDTH, WIDTH)
+    cam.set(cv2.CAP_PROP_FRAME_HEIGHT, HEIGHT)
+
+    img_counter = 0
+
+    while True:
+        ret, frame = cam.read()
+        frame = cv2.resize(frame,(224,224))
+
+        execute(frame)
+        frame = cv2.resize(frame,(640,640))
+        cv2.imshow("test", frame)
+        if not ret:
+            break
+        key = cv2.waitKey(1)
+        
+        # To close the window press "Q"
+        if key & 0xFF == ord('q') or key ==27:
+            break
+
+
+    cam.release()
+
+    cv2.destroyAllWindows()
+    
+    
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Using OpenCV to open camera instead of jetcam because many a times jetcam faces issues with USB camera and fails to initialise the camera.
Also adding a python script named live_demo.py, which can be directly run for inference by typing "python3 live_demo.py"